### PR TITLE
The-Wailing-Dwarf

### DIFF
--- a/ThroneoftheMadGod/worldmap/areas_bp_bgt.tbl
+++ b/ThroneoftheMadGod/worldmap/areas_bp_bgt.tbl
@@ -1,5 +1,5 @@
 
 SHORT_NAME  CONTENT  LONG_NAME  FLAGS  BAM_ANIM  X_POS   Y_POS  NAME         TOOLTIP  LOAD_IM
 
-ACIL10      ACIL10   ACIL10     0      221       2637   1071    @ACIL10      N        N
+ACIL10      ACIL10   ACIL10     0      220       2486   2795    @ACIL10      N        N
 


### PR DESCRIPTION
[It seem that the issue was simply a typo for the Bam anim and the Icon was misplaced.](https://www.gibberlings3.net/forums/topic/39354-mod-throne-of-the-mad-god-a-quest-mod-for-bg2ee/?do=findComment&comment=351382)

Below two screenshots when Throne of the MadGod is installed **_before_** BP-BGT-Worldmap.

If after testing the correction, the placement is to your liking feel free to add the pull request or if you don't want it you can add manually the change since [it's not much](https://github.com/11jo/Throne-of-the-Mad-God/commit/185b4888580e1b96a8a348818d9edc8f4632da34#diff-83db0480400781521f0925f82cdb2ec10fa25410ee8fde7804a0aa2d246c3a12).

Huge worldmap is used.

Edit : In this case 

- if you mod is installed **_before_** BP-BGT-Worldmap, then the Huge Worldmap will be automatically used
- if you mod is installed _**after**_ BP-BGT-Worldmap, and player use Huge Worldmap everything is fine.

- if you mod is installed **_after_** BP-BGT-Worldmap, and player use Large Worldmap _the icon will be misplaced on the y axe_.

It could be resolved easly if we could detect what worldmap (huge or large) is installed, but I don't know how (It's not notified in weidu.log and the installed files have the same name whatever Huge or Large is used)....

So unless you are willing to precise that your mod need to be installed _before_ BP-BGT-Worldmap like other mods adding new icon or only with Huge worldmap. 
Then I suppose someone more skilled will probably have a solution.

PS : I didn't plan to write this much, but it is what it is I guess, sorry to offer a incomplete solution.

----
Near Infinity

---
![NearInfinity](https://github.com/user-attachments/assets/a3a658b4-39b4-4f01-b0e7-6e5b12c4c628)

---
In EET with BP-BGT- Worldmap

---
![Game](https://github.com/user-attachments/assets/de364248-5f01-4d8b-9eca-0b8aa6a142f2)
